### PR TITLE
demo of service -> desktop mode with `keybd_event`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.23
 replace github.com/viam-labs/screenshot-cam => ../screenshot-cam
 
 require (
+	github.com/micmonay/keybd_event v1.1.2
 	github.com/viam-labs/screenshot-cam v0.0.0-00010101000000-000000000000
 	go.viam.com/rdk v0.60.1
 )

--- a/go.mod
+++ b/go.mod
@@ -2,9 +2,11 @@ module keystrokes
 
 go 1.23
 
+replace github.com/viam-labs/screenshot-cam => ../screenshot-cam
+
 require (
+	github.com/viam-labs/screenshot-cam v0.0.0-00010101000000-000000000000
 	go.viam.com/rdk v0.60.1
-	go.viam.com/utils v0.1.128
 )
 
 require (
@@ -20,10 +22,11 @@ require (
 	github.com/bep/debounce v1.2.1 // indirect
 	github.com/bluenviron/gortsplib/v4 v4.8.0 // indirect
 	github.com/bufbuild/protocompile v0.9.0 // indirect
-	github.com/bytedance/sonic v1.12.8 // indirect
+	github.com/bytedance/sonic/loader v0.2.2 // indirect
 	github.com/campoy/embedmd v1.0.0 // indirect
 	github.com/cenkalti/backoff v2.2.1+incompatible // indirect
 	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
+	github.com/cloudwego/base64x v0.1.5 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.2.0 // indirect
 	github.com/desertbit/timer v0.0.0-20180107155436-c41aec40b27f // indirect
@@ -98,6 +101,7 @@ require (
 	github.com/sergi/go-diff v1.3.1 // indirect
 	github.com/srikrsna/protoc-gen-gotag v0.6.2 // indirect
 	github.com/stretchr/testify v1.9.0 // indirect
+	github.com/twitchyliquid64/golang-asm v0.15.1 // indirect
 	github.com/viamrobotics/webrtc/v3 v3.99.10 // indirect
 	github.com/wlynxg/anet v0.0.3 // indirect
 	github.com/xdg-go/pbkdf2 v1.0.0 // indirect
@@ -119,6 +123,8 @@ require (
 	go.uber.org/zap v1.27.0 // indirect
 	go.viam.com/api v0.1.383 // indirect
 	go.viam.com/test v1.2.4 // indirect
+	go.viam.com/utils v0.1.128 // indirect
+	golang.org/x/arch v0.0.0-20210923205945-b76863e36670 // indirect
 	golang.org/x/crypto v0.28.0 // indirect
 	golang.org/x/exp v0.0.0-20240904232852-e7e105dedf7e // indirect
 	golang.org/x/image v0.19.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -577,6 +577,8 @@ github.com/matttproud/golang_protobuf_extensions v1.0.4/go.mod h1:BSXmuO+STAnVfr
 github.com/mbilski/exhaustivestruct v1.2.0/go.mod h1:OeTBVxQWoEmB2J2JCHmXWPJ0aksxSUOUy+nvtVEfzXc=
 github.com/mgechev/dots v0.0.0-20190921121421-c36f7dcfbb81/go.mod h1:KQ7+USdGKfpPjXk4Ga+5XxQM4Lm4e3gAogrreFAYpOg=
 github.com/mgechev/revive v1.0.3/go.mod h1:POGGZagSo/0frdr7VeAifzS5Uka0d0GPiM35MsTO8nE=
+github.com/micmonay/keybd_event v1.1.2 h1:RpgvPJKOh4Jc+ZYe0OrVzGd2eNMCfuVg3dFTCsuSah4=
+github.com/micmonay/keybd_event v1.1.2/go.mod h1:CGMWMDNgsfPljzrAWoybUOSKafQPZpv+rLigt2LzNGI=
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
 github.com/miekg/dns v1.1.41/go.mod h1:p6aan82bvRIyn+zDIv9xYNUpwa73JcSh9BKwknJysuI=
 github.com/miekg/dns v1.1.53 h1:ZBkuHr5dxHtB1caEOlZTLPo7D3L3TWckgUUs/RHfDxw=

--- a/go.sum
+++ b/go.sum
@@ -109,6 +109,7 @@ github.com/bufbuild/protocompile v0.9.0 h1:DI8qLG5PEO0Mu1Oj51YFPqtx6I3qYXUAhJVJ/
 github.com/bufbuild/protocompile v0.9.0/go.mod h1:s89m1O8CqSYpyE/YaSGtg1r1YFMF5nLTwh4vlj6O444=
 github.com/bytedance/sonic v1.12.8 h1:4xYRVRlXIgvSZ4e8iVTlMF5szgpXd4AfvuWgA8I8lgs=
 github.com/bytedance/sonic v1.12.8/go.mod h1:uVvFidNmlt9+wa31S1urfwwthTWteBgG0hWuoKAXTx8=
+github.com/bytedance/sonic/loader v0.1.1/go.mod h1:ncP89zfokxS5LZrJxl5z0UJcsk4M4yY2JpfqGeCtNLU=
 github.com/bytedance/sonic/loader v0.2.2 h1:jxAJuN9fOot/cyz5Q6dUuMJF5OqQ6+5GfA8FjjQ0R4o=
 github.com/bytedance/sonic/loader v0.2.2/go.mod h1:N8A3vUdtUebEY2/VQC0MyhYeKUFosQU6FxH2JmUe6VI=
 github.com/campoy/embedmd v1.0.0 h1:V4kI2qTJJLf4J29RzI/MAt2c3Bl4dQSYPuflzwFH2hY=
@@ -134,6 +135,7 @@ github.com/clbanning/x2j v0.0.0-20191024224557-825249438eec/go.mod h1:jMjuTZXRI4
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cloudwego/base64x v0.1.5 h1:XPciSp1xaq2VCSt6lF0phncD4koWyULpl5bUxbfCyP4=
 github.com/cloudwego/base64x v0.1.5/go.mod h1:0zlkT4Wn5C6NdauXdJRhSKRlJvmclQ1hhJgA0rcu/8w=
+github.com/cloudwego/iasm v0.2.0/go.mod h1:8rXZaNYT2n95jn+zTI1sDr+IgcD2GVs0nlbbQPiEFhY=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/cncf/udpa/go v0.0.0-20210930031921-04548b0d99d4/go.mod h1:6pvJx4me5XPnfI9Z40ddWsdw2W/uZgQLFXToKeRcDiI=
@@ -501,6 +503,7 @@ github.com/klauspost/compress v1.17.7 h1:ehO88t2UGzQK66LMdE8tibEd1ErmzZjNEqWkjLA
 github.com/klauspost/compress v1.17.7/go.mod h1:Di0epgTjJY877eYKx5yC51cX2A2Vl2ibi7bDH9ttBbw=
 github.com/klauspost/cpuid/v2 v2.0.9 h1:lgaqFMSdTdQYdZ04uHyN2d/eKdOMyi2YLSvlQIBFYa4=
 github.com/klauspost/cpuid/v2 v2.0.9/go.mod h1:FInQzS24/EEf25PyTYn52gqo7WaD8xa0213Md/qVLRg=
+github.com/knz/go-libedit v1.10.1/go.mod h1:MZTVkCWyz0oBc7JOWP3wNAzd002ZbM/5hgShxwh4x8M=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.3/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/fs v0.1.0/go.mod h1:FFnZGqtBN9Gxj7eW1uZ42v5BccTP0vu6NEaFoC2HwRg=
@@ -1407,6 +1410,7 @@ mvdan.cc/unparam v0.0.0-20210104141923-aac4ce9116a7/go.mod h1:hBpJkZE8H/sb+VRFvw
 nhooyr.io/websocket v1.8.6/go.mod h1:B70DZP8IakI65RVQ51MsWP/8jndNma26DVA/nFSCgW0=
 nhooyr.io/websocket v1.8.7 h1:usjR2uOr/zjjkVMy0lW+PPohFok7PCow5sDjLgX4P4g=
 nhooyr.io/websocket v1.8.7/go.mod h1:B70DZP8IakI65RVQ51MsWP/8jndNma26DVA/nFSCgW0=
+nullprogram.com/x/optparse v1.0.0/go.mod h1:KdyPE+Igbe0jQUrVfMqDMeJQIJZEuyV7pjYmp6pbG50=
 periph.io/x/conn/v3 v3.7.0 h1:f1EXLn4pkf7AEWwkol2gilCNZ0ElY+bxS4WE2PQXfrA=
 periph.io/x/conn/v3 v3.7.0/go.mod h1:ypY7UVxgDbP9PJGwFSVelRRagxyXYfttVh7hJZUHEhg=
 periph.io/x/host/v3 v3.8.1-0.20230331112814-9f0d9f7d76db h1:8+HL7DJFofYRhGoK/UdwhzvQj3I2HrKLQ6dkOC66CZY=

--- a/main.go
+++ b/main.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"context"
+	"encoding/base64"
 	"keystrokes/models"
 	"os"
 	"time"
@@ -27,22 +29,28 @@ func SendKeys() {
 func main() {
 	logger := module.NewLoggerFromArgs("screenshot-cam")
 	var arg string
-	if len(os.Args) >= 2 {
+	var arg2 string
+	if len(os.Args) >= 3 {
 		arg = os.Args[1]
+		arg2 = os.Args[2]
 	}
 	switch arg {
 	case "parent":
+		arg2 := base64.StdEncoding.EncodeToString([]byte(`{"keystrokes": [{"type":"sequential", "keys": ["A", "B", "C"]}]}`))
 		// parent is a test mode for spawning a child proc directly from session 0 CLI. see README.md for instructions.
-		if err := subproc.SpawnSelf(" child"); err != nil {
+		if err := subproc.SpawnSelf(" child " + arg2); err != nil {
 			panic(err)
 		}
 	case "child":
+		jsonArg, err := base64.StdEncoding.DecodeString(arg2)
+		if err != nil {
+			panic(err)
+		}
 		// child is the subprocess started in session 1 by a session 0 parent. it does the work.
 		logger.Info("child mode: doing a keystrokes test instead of starting module")
-		// if err := models.DemoMode(context.Background(), logger); err != nil {
-		// 	panic(err)
-		// }
-		SendKeys()
+		if err := models.DemoMode(context.Background(), logger, jsonArg); err != nil {
+			panic(err)
+		}
 	default:
 		// ModularMain can take multiple APIModel arguments, if your module implements multiple models.
 		module.ModularMain(resource.APIModel{generic.API, models.Keypresser})

--- a/main.go
+++ b/main.go
@@ -1,15 +1,28 @@
 package main
 
 import (
-	"context"
 	"keystrokes/models"
 	"os"
+	"time"
 
+	"github.com/micmonay/keybd_event"
 	"github.com/viam-labs/screenshot-cam/subproc"
 	"go.viam.com/rdk/components/generic"
 	"go.viam.com/rdk/module"
 	"go.viam.com/rdk/resource"
 )
+
+func SendKeys() {
+	time.Sleep(time.Second * 2)
+	kb, err := keybd_event.NewKeyBonding()
+	if err != nil {
+		panic(err)
+	}
+	kb.SetKeys(keybd_event.VK_A, keybd_event.VK_B)
+	if err := kb.Launching(); err != nil {
+		panic(err)
+	}
+}
 
 func main() {
 	logger := module.NewLoggerFromArgs("screenshot-cam")
@@ -26,9 +39,10 @@ func main() {
 	case "child":
 		// child is the subprocess started in session 1 by a session 0 parent. it does the work.
 		logger.Info("child mode: doing a keystrokes test instead of starting module")
-		if err := models.DemoMode(context.Background(), logger); err != nil {
-			panic(err)
-		}
+		// if err := models.DemoMode(context.Background(), logger); err != nil {
+		// 	panic(err)
+		// }
+		SendKeys()
 	default:
 		// ModularMain can take multiple APIModel arguments, if your module implements multiple models.
 		module.ModularMain(resource.APIModel{generic.API, models.Keypresser})

--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"keystrokes/models"
 	"os"
 
@@ -24,7 +25,10 @@ func main() {
 		}
 	case "child":
 		// child is the subprocess started in session 1 by a session 0 parent. it does the work.
-		logger.Info("doing a keystrokes test instead of starting module")
+		logger.Info("child mode: doing a keystrokes test instead of starting module")
+		if err := models.DemoMode(context.Background(), logger); err != nil {
+			panic(err)
+		}
 	default:
 		// ModularMain can take multiple APIModel arguments, if your module implements multiple models.
 		module.ModularMain(resource.APIModel{generic.API, models.Keypresser})

--- a/main.go
+++ b/main.go
@@ -36,17 +36,17 @@ func main() {
 	}
 	switch arg {
 	case "parent":
-		arg2 := base64.StdEncoding.EncodeToString([]byte(`{"keystrokes": [{"type":"sequential", "keys": ["A", "B", "C"]}]}`))
 		// parent is a test mode for spawning a child proc directly from session 0 CLI. see README.md for instructions.
+		arg2 := base64.StdEncoding.EncodeToString([]byte(`{"keystrokes": [{"type":"sequential", "keys": ["A", "B", "C"]}]}`))
 		if err := subproc.SpawnSelf(" child " + arg2); err != nil {
 			panic(err)
 		}
 	case "child":
+		// child is the subprocess started in session 1, by a session 0 parent. it interacts with the user desktop.
 		jsonArg, err := base64.StdEncoding.DecodeString(arg2)
 		if err != nil {
 			panic(err)
 		}
-		// child is the subprocess started in session 1 by a session 0 parent. it does the work.
 		logger.Info("child mode: doing a keystrokes test instead of starting module")
 		if err := models.DemoMode(context.Background(), logger, jsonArg); err != nil {
 			panic(err)

--- a/main.go
+++ b/main.go
@@ -2,12 +2,31 @@ package main
 
 import (
 	"keystrokes/models"
+	"os"
+
+	"github.com/viam-labs/screenshot-cam/subproc"
+	"go.viam.com/rdk/components/generic"
 	"go.viam.com/rdk/module"
 	"go.viam.com/rdk/resource"
-	"go.viam.com/rdk/components/generic"
 )
 
 func main() {
-	// ModularMain can take multiple APIModel arguments, if your module implements multiple models.
-	module.ModularMain(resource.APIModel{ generic.API, models.Keypresser})
+	logger := module.NewLoggerFromArgs("screenshot-cam")
+	var arg string
+	if len(os.Args) >= 2 {
+		arg = os.Args[1]
+	}
+	switch arg {
+	case "parent":
+		// parent is a test mode for spawning a child proc directly from session 0 CLI. see README.md for instructions.
+		if err := subproc.SpawnSelf(" child"); err != nil {
+			panic(err)
+		}
+	case "child":
+		// child is the subprocess started in session 1 by a session 0 parent. it does the work.
+		logger.Info("doing a keystrokes test instead of starting module")
+	default:
+		// ModularMain can take multiple APIModel arguments, if your module implements multiple models.
+		module.ModularMain(resource.APIModel{generic.API, models.Keypresser})
+	}
 }

--- a/models/module.go
+++ b/models/module.go
@@ -2,9 +2,12 @@ package models
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 
+	"github.com/micmonay/keybd_event"
+	"github.com/viam-labs/screenshot-cam/subproc"
 	"go.viam.com/rdk/components/generic"
 	"go.viam.com/rdk/logging"
 	"go.viam.com/rdk/resource"
@@ -62,109 +65,121 @@ func (s *keystrokesKeypresser) Name() resource.Name {
 	return s.name
 }
 
-func (s *keystrokesKeypresser) DoCommand(ctx context.Context, cmd map[string]interface{}) (map[string]interface{}, error) {
-	type KeypressType string
-	const (
-		Sequential   KeypressType = "sequential"
-		Simultaneous KeypressType = "simultaneous"
-	)
-	type Keystroke struct {
-		Type KeypressType `json:"type"`
-		Keys []string     `json:"keys"`
-	}
-	type Command struct {
-		Keystrokes []Keystroke `json:"keystrokes"`
-	}
+type KeypressType string
 
+const (
+	Sequential   KeypressType = "sequential"
+	Simultaneous KeypressType = "simultaneous"
+)
+
+type Keystroke struct {
+	Type KeypressType `json:"type"`
+	Keys []string     `json:"keys"`
+}
+type Command struct {
+	Keystrokes []Keystroke `json:"keystrokes"`
+}
+
+func (s *keystrokesKeypresser) DoCommand(ctx context.Context, cmd map[string]interface{}) (map[string]interface{}, error) {
 	jsonbody, err := json.Marshal(cmd)
 	if err != nil {
 		return nil, fmt.Errorf("could not convert command into JSON: %w", err)
 	}
 
-	command := Command{}
-	if err := json.Unmarshal(jsonbody, &command); err != nil {
-		return nil, fmt.Errorf("could not unmarshall command JSON to appropriate type: %w", err)
+	// todo: only do subproc when needed; it won't work in non-service mode
+
+	jsonArg := base64.StdEncoding.EncodeToString(jsonbody)
+	// parent is a test mode for spawning a child proc directly from session 0 CLI. see README.md for instructions.
+	if err := subproc.SpawnSelf(" child " + jsonArg); err != nil {
+		panic(err)
 	}
 
-	for _, keystroke := range command.Keystrokes {
-		if keystroke.Type == Simultaneous {
-			pressed := []int{}
-			for _, keys := range keystroke.Keys {
-				// Check if meta key and press/release immediately
-				// Otherwise, go rune by rune
-				if key, ok := keymap[keys]; ok {
-					if err := Press(key); err != nil {
-						return nil, err
-					}
-					pressed = append(pressed, key)
-				} else {
-					for _, r := range keys {
-						if key := GetKey(r); key >= 0 {
-							if err := Press(key); err != nil {
-								return nil, err
-							}
-							pressed = append(pressed, key)
-						}
-					}
-				}
-			}
-			for i := len(pressed) - 1; i >= 0; i-- {
-				if err := Release(pressed[i]); err != nil {
-					return nil, err
-				}
-			}
-		} else if keystroke.Type == Sequential {
-			for _, keys := range keystroke.Keys {
-				// Check if meta key and press/release immediately
-				// Otherwise, go rune by rune
-				if key, ok := keymap[keys]; ok {
-					if err := Press(key); err != nil {
-						return nil, err
-					}
-					if err := Release(key); err != nil {
-						return nil, err
-					}
-				} else {
-					for _, r := range keys {
-						if key := GetKey(r); key >= 0 {
-							if err := Press(key); err != nil {
-								return nil, err
-							}
-							if err := Release(key); err != nil {
-								return nil, err
-							}
-						}
-					}
-				}
-			}
-		}
-	}
+	// for _, keystroke := range command.Keystrokes {
+	// 	if keystroke.Type == Simultaneous {
+	// 		pressed := []int{}
+	// 		for _, keys := range keystroke.Keys {
+	// 			// Check if meta key and press/release immediately
+	// 			// Otherwise, go rune by rune
+	// 			if key, ok := keymap[keys]; ok {
+	// 				if err := Press(key); err != nil {
+	// 					return nil, err
+	// 				}
+	// 				pressed = append(pressed, key)
+	// 			} else {
+	// 				for _, r := range keys {
+	// 					if key := GetKey(r); key >= 0 {
+	// 						if err := Press(key); err != nil {
+	// 							return nil, err
+	// 						}
+	// 						pressed = append(pressed, key)
+	// 					}
+	// 				}
+	// 			}
+	// 		}
+	// 		for i := len(pressed) - 1; i >= 0; i-- {
+	// 			if err := Release(pressed[i]); err != nil {
+	// 				return nil, err
+	// 			}
+	// 		}
+	// 	} else if keystroke.Type == Sequential {
+	// 		for _, keys := range keystroke.Keys {
+	// 			// Check if meta key and press/release immediately
+	// 			// Otherwise, go rune by rune
+	// 			if key, ok := keymap[keys]; ok {
+	// 				if err := Press(key); err != nil {
+	// 					return nil, err
+	// 				}
+	// 				if err := Release(key); err != nil {
+	// 					return nil, err
+	// 				}
+	// 			} else {
+	// 				for _, r := range keys {
+	// 					if key := GetKey(r); key >= 0 {
+	// 						if err := Press(key); err != nil {
+	// 							return nil, err
+	// 						}
+	// 						if err := Release(key); err != nil {
+	// 							return nil, err
+	// 						}
+	// 					}
+	// 				}
+	// 			}
+	// 		}
+	// 	}
+	// }
 
 	return nil, nil
 }
 
-func DemoMode(ctx context.Context, logger logging.Logger) error {
+func DemoMode(ctx context.Context, logger logging.Logger, jsonArg []byte) error {
 	// cancelCtx, cancelFunc := context.WithCancel(context.Background())
 
-	kp := &keystrokesKeypresser{
-		logger: logger,
-		cfg:    &Config{},
-		// cancelCtx:  cancelCtx,
-		// cancelFunc: cancelFunc,
-	}
-	demo := `{
-		"keystrokes": [
-			{"type": "simultaneous", "keys": ["VK_META"]},
-			{"type": "sequential", "keys": ["notepad", "VK_ENTER"]},
-			{"type": "sequential", "keys": ["Hello", " ", "World"]},
-			{"type": "simultaneous", "keys": ["VK_SHIFT", "1"]}
-		]
-	}`
-	var cmd map[string]any
-	err := json.Unmarshal([]byte(demo), &cmd)
+	// demo := `{
+	// 	"keystrokes": [
+	// 		{"type": "simultaneous", "keys": ["VK_META"]},
+	// 		{"type": "sequential", "keys": ["notepad", "VK_ENTER"]},
+	// 		{"type": "sequential", "keys": ["Hello", " ", "World"]},
+	// 		{"type": "simultaneous", "keys": ["VK_SHIFT", "1"]}
+	// 	]
+	// }`
+	var command Command
+	err := json.Unmarshal(jsonArg, &command)
 	if err != nil {
 		return err
 	}
-	_, err = kp.DoCommand(ctx, cmd)
-	return err
+	for _, keystroke := range command.Keystrokes {
+		kb, err := keybd_event.NewKeyBonding()
+		if err != nil {
+			return err
+		}
+		for range keystroke.Keys {
+			println("SETTING KEY A")
+			kb.SetKeys(keybd_event.VK_A)
+		}
+		if err := kb.Launching(); err != nil {
+			return err
+		}
+		println("OK LAUNCH")
+	}
+	return nil
 }


### PR DESCRIPTION
This seems to work using the pstools test instructions here https://github.com/viam-labs/screenshot-cam#subprocess-control, for testing session 0 -> session 1 injection.

(Just look at the `SendKeys` function with parent/child in main.go -- ignore + discard the other changes)

I didn't test in full rdk service mode; handing off to you but ping if anything I can help with