### PR TITLE
Fix JSON syntax in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,11 +32,11 @@ The following attributes are available for this model:
       },
       {
         "command": "keystroke",
-        "mode": "sequential"
+        "mode": "sequential",
         "keys": [
           "notepad",
           "VK_ENTER"
-        ],
+        ]
       },
       {
         "command": "keystroke",

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Send a `doCommand` to the component. The structure of the command must be as fol
         {"command": "keystroke", "mode": "<sequential|simultaneous>", "keys": ["<keys>", "<to>", "<press>"]},
 		{"command": "mouse_event", "type": "<left_click|right_click|double_click>", "x": <x_coord>, "y": <y_coord>},
 		{"command": "sleep", "ms": <MS_TO_SLEEP>},
-		{"command": "macro", "name" "<macro_name>"}
+		{"command": "macro", "name": "<macro_name>"}
     ]
 }
 ```


### PR DESCRIPTION
Pasting the example config from the README into a machine does not work because of JSON syntax errors.