### PR TITLE
Fix nil Named panic on resource removal and make Close cancel its context

### DIFF
--- a/models/module.go
+++ b/models/module.go
@@ -35,7 +35,7 @@ type Config struct {
 }
 
 type keystrokesKeypresser struct {
-	name resource.Name
+	resource.Named
 
 	logger logging.Logger
 	cfg    *Config
@@ -43,9 +43,6 @@ type keystrokesKeypresser struct {
 
 	cancelCtx  context.Context
 	cancelFunc func()
-
-	resource.Named
-	resource.TriviallyCloseable
 }
 
 func getMacrosFromAttrs(attrs utils.AttributeMap) (Macros, error) {
@@ -77,7 +74,7 @@ func newKeystrokesKeypresser(ctx context.Context, deps resource.Dependencies, ra
 	cancelCtx, cancelFunc := context.WithCancel(context.Background())
 
 	s := &keystrokesKeypresser{
-		name:       rawConf.ResourceName(),
+		Named:      rawConf.ResourceName().AsNamed(),
 		logger:     logger,
 		cfg:        conf,
 		macros:     macros,
@@ -85,6 +82,11 @@ func newKeystrokesKeypresser(ctx context.Context, deps resource.Dependencies, ra
 		cancelFunc: cancelFunc,
 	}
 	return s, nil
+}
+
+func (s *keystrokesKeypresser) Close(ctx context.Context) error {
+	s.cancelFunc()
+	return nil
 }
 
 func (s *keystrokesKeypresser) Reconfigure(ctx context.Context, deps resource.Dependencies, conf resource.Config) error {


### PR DESCRIPTION
## Summary

Fixes a panic that kills the module process every time a resource is removed -
i.e. on every restart, reconfigure, or machine shutdown.

`keystrokesKeypresser` embeds `resource.Named` but the constructor never
initializes it, so the promoted `Name()` dereferences a nil interface. Nothing
calls `Name()` on the happy path, so the bug stays invisible until teardown:

    panic: runtime error: invalid memory address or nil pointer dereference
    [signal 0xc0000005 code=0x0 addr=0x20]
    goroutine 113 [running]:
    keystrokes/models.(*keystrokesKeypresser).Name(...)   <autogenerated>:1
    go.viam.com/rdk/module.(*Module).removeResource(...)  module/resources.go:415

`resources.go:415` is `delete(m.streamSourceByName, res.Name())`, the first
`res.Name()` call after `res.Close(ctx)`. The module dies mid-RPC, so
viam-server reports `Error removing resource ... An existing connection was
forcibly closed by the remote host` and the resource never shuts down cleanly.

## Changes

**Initialize the embedded `resource.Named` (the crash).** The constructor now
sets `Named: rawConf.ResourceName().AsNamed()`. Removes the `name resource.Name`
field, which has been write-only since the explicit `Name()` method was dropped.
`AsNamed()` also supplies `Status()`

**Replace `resource.TriviallyCloseable` with a real `Close()`.** `Close()` was a
no-op, so the `cancelFunc` from the constructor's `context.WithCancel` was never
called. `Close()` now calls it.